### PR TITLE
Fix gem license path

### DIFF
--- a/default-avatar-generator.gemspec
+++ b/default-avatar-generator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob(%w[
                           lib/**/*
                           README.md
-                          LICENSE.txt
+                          LICENSE
                           CHANGELOG.md
                         ])
   spec.require_paths = ['lib']


### PR DESCRIPTION
## Summary
- fix missing license path in gemspec

## Testing
- `bundle3.2 exec rspec --format doc` *(fails: Could not find nokogiri-1.18.7)*

------
https://chatgpt.com/codex/tasks/task_e_687926133a20832cb7d07b98dfdc5915