### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/pas256/default-avatar-generator/security/code-scanning/2](https://github.com/pas256/default-avatar-generator/security/code-scanning/2)

To resolve the issue, add a `permissions` block to the workflow. The least privilege principle should be applied, granting only the permissions required for each job. In this case:
1. The `lint` job only reads the repository content and does not perform any write operations, so `contents: read` is sufficient.
2. Similarly, the `test` job reads the repository content and does not require write permissions, so `contents: read` is also appropriate.

The `permissions` block can be added either at the root level to apply to all jobs or within each job for finer control. In this case, we'll add it to the root for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
