### PR TITLE
Fix gemspec metadata warning

### DIFF
--- a/default-avatar-generator.gemspec
+++ b/default-avatar-generator.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = '>= 3.0.0'
 
-  spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 


### PR DESCRIPTION
## Summary
- remove duplicated `homepage_uri` metadata

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68796ede0ed0832c86bb1a0a958a593a