### PR TITLE
Add Colors specs

### DIFF
--- a/spec/default_avatar_generator/colors_spec.rb
+++ b/spec/default_avatar_generator/colors_spec.rb
@@ -3,12 +3,16 @@
 require 'spec_helper'
 
 RSpec.describe DefaultAvatarGenerator::Colors do
+  let(:valid_colors_for) do |shades_method|
+    described_class::COLORS.values.flat_map do |shades|
+      described_class.send(shades_method).map { |s| shades[s] }
+    end
+  end
+
   describe '.select_solid_color' do
     it 'returns a hex color from the solid shades' do
       color = described_class.select_solid_color
-      valid_colors = described_class::COLORS.values.flat_map do |shades|
-        described_class.solid_shades.map { |s| shades[s] }
-      end
+      valid_colors = valid_colors_for(:solid_shades)
       expect(valid_colors).to include(color)
       expect(color).to match(/^#[0-9a-f]{6}$/i)
     end

--- a/spec/default_avatar_generator/colors_spec.rb
+++ b/spec/default_avatar_generator/colors_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DefaultAvatarGenerator::Colors do
+  describe '.select_solid_color' do
+    it 'returns a hex color from the solid shades' do
+      color = described_class.select_solid_color
+      valid_colors = described_class::COLORS.values.flat_map do |shades|
+        described_class.solid_shades.map { |s| shades[s] }
+      end
+      expect(valid_colors).to include(color)
+      expect(color).to match(/^#[0-9a-f]{6}$/i)
+    end
+  end
+
+  describe '.select_contrast_color' do
+    it 'returns a hex color from the contrast shades' do
+      color = described_class.select_contrast_color
+      valid_colors = described_class::COLORS.values.flat_map do |shades|
+        described_class.contrast_shades.map { |s| shades[s] }
+      end
+      expect(valid_colors).to include(color)
+      expect(color).to match(/^#[0-9a-f]{6}$/i)
+    end
+  end
+
+  describe '.opposite_shade' do
+    it 'returns the correct opposite for given shades' do
+      expect(described_class.opposite_shade(50)).to eq(950)
+      expect(described_class.opposite_shade(300)).to eq(700)
+      expect(described_class.opposite_shade(500)).to eq(500)
+      expect(described_class.opposite_shade(900)).to eq(100)
+    end
+  end
+end

--- a/spec/default_avatar_generator/colors_spec.rb
+++ b/spec/default_avatar_generator/colors_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe DefaultAvatarGenerator::Colors do
   describe '.select_contrast_color' do
     it 'returns a hex color from the contrast shades' do
       color = described_class.select_contrast_color
-      valid_colors = described_class::COLORS.values.flat_map do |shades|
-        described_class.contrast_shades.map { |s| shades[s] }
-      end
+      valid_colors = valid_colors_for(:contrast_shades)
       expect(valid_colors).to include(color)
       expect(color).to match(/^#[0-9a-f]{6}$/i)
     end

--- a/spec/default_avatar_generator/colors_spec.rb
+++ b/spec/default_avatar_generator/colors_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe DefaultAvatarGenerator::Colors do
-  let(:valid_colors_for) do |shades_method|
+  def valid_colors_for(shades_method)
     described_class::COLORS.values.flat_map do |shades|
       described_class.send(shades_method).map { |s| shades[s] }
     end


### PR DESCRIPTION
## Summary
- add tests for selecting random colors and opposite shades

## Testing
- `bundle exec rake spec`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_68796f19dbd8832ca420cbe1d611c400